### PR TITLE
Authenticate via Trusted Publishers when publishing NPM package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - v[0-9].*
-permissions:
-  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Goals/Scope

Remove the need to share an access token between NPM and GitHub.

## Description

Change workflow to make use of https://docs.npmjs.com/trusted-publishers. Also, when using Trusted Publishers, the package will automatically include provenance attestation (https://docs.npmjs.com/generating-provenance-statements).

### How to Test

Publish a new package. It should Just Work (tm). The settings on npmjs.org have already been adjusted (to disallow publishing using an access token).

## Comments

Once the workflow is verified to work, remove `NPM_AUTH_TOKEN` secret from the GitHub repository.

---

- [ ] Timeframe: [`24 hr`, `3 days`, `1 week`]
- [ ] Urgent!
- [ ] Merge without review
- [ ] cc: @person
